### PR TITLE
Fix readme mode

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -42,7 +42,7 @@ mv sd-v1-4.ckpt models/ldm/stable-diffusion-v1/model.ckpt
 | Steps           | [1, 1000]                               | The number of steps to optimize the watermark.               |
 | Output size     | {256, 512, 768}                         | The size of the output image, square only.                   |
 | Blocking Number | {1(1x1), 2 (2x2)}                       | If true, separate the image into blocks of BxB and add watermarks to these blocks, respectively. |
-| Mode            | {0 (textural), 1 (semantic), 2 (fused)} | Watermark mode. See documentation for details.               |
+| Mode            | {0 (semantic), 1 (textural), 2 (fused)} | Watermark mode. See documentation for details.               |
 | Fused weight    | [1, 5]                                  | Balance the weight of textural mode and semantic mode in fused mode. |
 
 The parameters must be provided in sequence as mentioned in the table. For example, use the following command to Mist the image with Strength 16, Steps 100, output size 512, blocking number 1, mode 2 (fused mode), and fused weight 1:


### PR DESCRIPTION
Modes in the Readme.md do not match with code
Mode in Readme.md -> (0) textural (1) semantic (2) fused

![Screenshot from 2024-11-03 13-09-22](https://github.com/user-attachments/assets/147fce41-1c40-49d4-b17b-1e7ec3a0a626)

Mode in mist_v3.py (line 96, line 164) -> (0) semantic (1) textural (2) fused

![Screenshot from 2024-11-03 13-08-50](https://github.com/user-attachments/assets/c37a706a-0a21-4695-8cce-3d7048d9ad82)

![Screenshot from 2024-11-03 13-09-10](https://github.com/user-attachments/assets/fd4bf591-aba7-486d-a9cf-2f9520d3328a)
